### PR TITLE
修复tab补全时始终基于根目录的问题

### DIFF
--- a/src/shell/command/mod.rs
+++ b/src/shell/command/mod.rs
@@ -244,21 +244,14 @@ impl Shell {
     }
 
     fn shell_cmd_ls(&self, args: &Vec<String>) -> Result<(), CommandError> {
-        let mut path = String::new();
-        if args.len() == 0 {
-            path = self.current_dir();
-        }
-        if args.len() == 1 {
-            path = args.get(0).unwrap().clone();
-            match self.is_dir(&path) {
-                Ok(str) => path = str,
+        let path: String = match args.len() {
+            0 => self.current_dir(),
+            1 => match self.is_dir(args.get(0).unwrap()) {
+                Ok(str) => str,
                 Err(e) => return Err(e),
-            }
-        }
-
-        if path.is_empty() {
-            return Err(CommandError::WrongArgumentCount(args.len()));
-        }
+            },
+            _ => return Err(CommandError::WrongArgumentCount(args.len())),
+        };
 
         let dir: fs::ReadDir;
         match fs::read_dir(Path::new(&path)) {

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -216,7 +216,10 @@ impl Shell {
                                     } else {
                                         incomplete_len = incomplete_frag.len();
                                     }
-                                    Printer::complete_path(incomplete_frag)
+                                    Printer::complete_path(
+                                        format!("{}/{}", self.current_dir, incomplete_frag)
+                                            .as_str(),
+                                    )
                                 }
                                 _ => Vec::new(),
                             };
@@ -240,7 +243,16 @@ impl Shell {
                                     Printer::print(&buf[cursor..buf.len()]);
                                     println!();
                                     for candidate in candidates {
-                                        print!("{candidate}    ");
+                                        if candidate.ends_with('/') {
+                                            crate::shell::Printer::print_color(
+                                                candidate.as_bytes(),
+                                                0x000088ff,
+                                                0x00000000,
+                                            );
+                                            print!("    ");
+                                        } else {
+                                            print!("{candidate}    ");
+                                        }
                                     }
                                     println!();
                                     Printer::print_prompt(&prompt);
@@ -358,6 +370,7 @@ impl Printer {
     }
 
     fn complete_path(path: &str) -> Vec<String> {
+        // println!("{}", path);
         let mut candidates: Vec<String> = Vec::new();
         let dir: &str;
         let incomplete_name: &str;


### PR DESCRIPTION
修复tab补全时始终基于根目录的问题
tab补全遇到目录显示为蓝色