### PR TITLE
fix:  错误处理 ; ' " 导致的崩溃

### DIFF
--- a/src/shell/command/mod.rs
+++ b/src/shell/command/mod.rs
@@ -101,12 +101,11 @@ impl Command {
         let mut iter = regex.captures_iter(hay.as_str()).map(|c| {
             let str = c.get(0).unwrap().as_str();
             if str.starts_with(|char| char == '\'' || char == '\"')
-                && str.ends_with(|char| char == '\'' || char == '\"')
+                && str.ends_with(|char| char == '\'' || char == '\"') && str.len() != 1
             {
                 return str[1..str.len() - 1].to_string();
-            } else {
-                return str.to_string();
-            }
+            } 
+            return str.to_string();
         });
         let name = iter.next().unwrap();
         let re: Regex = Regex::new(r"\$[\w_]+").unwrap();
@@ -133,15 +132,22 @@ impl Command {
     }
 
     pub fn from_strings(str: String) -> Vec<Command> {
-        str.split(';')
-            .filter_map(|s| match Command::from_string(String::from(s)) {
-                Ok(s) => Some(s),
-                Err(e) => {
-                    CommandError::handle(e);
-                    None
+        let mut commands = Vec::new();
+        let segments: Vec<&str> = str.split(';').collect();
+        for segment in segments {
+            if segment.trim().is_empty() {
+                continue;
+            } else {
+                match  Command::from_string(String::from(segment)) {
+                    Ok(s) => commands.push(s),
+                    Err(e) => {
+                        CommandError::handle(e);
+                    }
                 }
-            })
-            .collect::<Vec<Command>>()
+            }
+        }
+
+        commands 
     }
 }
 


### PR DESCRIPTION
修复用户输入以下情况造成系统重启：
1、命令第一个字符为;
2、命令最后一个字符为;
3、命令中间有连续的;
4、两个;中间隔着空格
5、单独输入'或"