### PR TITLE
修改issues#38 bug: history_commands没记录到txt中

### DIFF
--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -101,12 +101,12 @@ impl Shell {
             {
                 self.history_commands
                     .push(Rc::new(RefCell::new(command_bytes.clone())));
+                self.write_commands();
             };
             if !command_bytes.iter().all(|&byte| byte == b' ') {
                 self.exec_commands_in_line(&command_bytes);
             }
         }
-        self.write_commands();
     }
 
     fn exec_commands_in_line(&mut self, command_bytes: &Vec<u8>) {
@@ -136,7 +136,7 @@ impl Shell {
 
     fn write_commands(&self) {
         let mut file = OpenOptions::new()
-            .append(false)
+            .write(true).truncate(true)
             .open("history_commands.txt")
             .unwrap();
         for command_line in &self.history_commands {

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -136,7 +136,8 @@ impl Shell {
 
     fn write_commands(&self) {
         let mut file = OpenOptions::new()
-            .write(true).truncate(true)
+            .write(true)
+            .truncate(true)
             .open("history_commands.txt")
             .unwrap();
         for command_line in &self.history_commands {


### PR DESCRIPTION
修改issues#38 bug: history_commands没记录到txt中
在添加当前command到history_commands变量后，马上执行history_commands记录到txt的操作